### PR TITLE
Move the command line options of phantomjs at the beggining of the exec command

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,27 +156,26 @@ Screenshot.prototype.capture = function(fn) {
     }
   }
 
-  var args = [
-    __dirname + '/script/render.js', this.url,
-    this._width, this._height, this._timeout, this._format, this._clip
-  ];
+  var args = []
 
-  var cliOpts = [];
   if (this._ignoreSslErrors) {
-    cliOpts.push('--ignore-ssl-errors=true');
+    args.push('--ignore-ssl-errors=true');
   }
   if (this._sslCertificatesPath) {
-    cliOpts.push('--ssl-certificates-path=' + this._sslCertificatesPath);
+    args.push('--ssl-certificates-path=' + this._sslCertificatesPath);
   }
   if (this._sslProtocol) {
-    cliOpts.push('--ssl-protocol=' + this._sslProtocol);
+    args.push('--ssl-protocol=' + this._sslProtocol);
   }
+
+  args.push(__dirname + '/script/render.js', this.url,
+  this._width, this._height, this._timeout, this._format, this._clip);
 
   var opts = {
     maxBuffer: Infinity
   };
 
-  exec('phantomjs ' + cliOpts.join(' ') + ' ' + args.join(' '), opts, function (err, stdout) {
+  exec('phantomjs ' + args.join(' '), opts, function (err, stdout) {
     fn(err, stdout && new Buffer(stdout, 'base64'));
   });
 };

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ Screenshot.prototype.timeout = function(timeout) {
  *   - jpg, jpeg
  *   - png
  *   - gif
- *   
+ *
  * @param {String} format
  * @throws {TypeError}
  * @return {Screenshot}
@@ -115,7 +115,7 @@ Screenshot.prototype.sslCertificatesPath = function(path) {
  * Set the SSL protocol to be used.
  *
  * Supported protocols:
- * 
+ *
  *   - sslv3
  *   - sslv2
  *   - tlsv1
@@ -160,23 +160,23 @@ Screenshot.prototype.capture = function(fn) {
     __dirname + '/script/render.js', this.url,
     this._width, this._height, this._timeout, this._format, this._clip
   ];
-  
+
+  var cliOpts = [];
   if (this._ignoreSslErrors) {
-    args.push('--ignore-ssl-errors');
+    cliOpts.push('--ignore-ssl-errors=true');
   }
   if (this._sslCertificatesPath) {
-    args.push('--ssl-certificates-path=' + this._sslCertificatesPath);
+    cliOpts.push('--ssl-certificates-path=' + this._sslCertificatesPath);
   }
   if (this._sslProtocol) {
-    args.push('--ssl-protocol=' + this._sslProtocol);
+    cliOpts.push('--ssl-protocol=' + this._sslProtocol);
   }
 
   var opts = {
     maxBuffer: Infinity
   };
 
-  exec('phantomjs ' + args.join(' '), opts, function (err, stdout) {
+  exec('phantomjs ' + cliOpts.join(' ') + args.join(' '), opts, function (err, stdout) {
     fn(err, stdout && new Buffer(stdout, 'base64'));
   });
 };
-

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ Screenshot.prototype.capture = function(fn) {
     }
   }
 
-  var args = []
+  var args = [];
 
   if (this._ignoreSslErrors) {
     args.push('--ignore-ssl-errors=true');

--- a/index.js
+++ b/index.js
@@ -157,14 +157,7 @@ Screenshot.prototype.capture = function (fn) {
     };
   }
 
-<<<<<<< HEAD
   var args = [];
-=======
-  var args = [
-    join(__dirname, '/script/render.js'), this.url,
-    this._width, this._height, this._timeout, this._format, this._clip
-  ];
->>>>>>> upstream/master
 
   if (this._ignoreSslErrors) {
     args.push('--ignore-ssl-errors=true');

--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ Screenshot.prototype.capture = function(fn) {
     maxBuffer: Infinity
   };
 
-  exec('phantomjs ' + cliOpts.join(' ') + args.join(' '), opts, function (err, stdout) {
+  exec('phantomjs ' + cliOpts.join(' ') + ' ' + args.join(' '), opts, function (err, stdout) {
     fn(err, stdout && new Buffer(stdout, 'base64'));
   });
 };


### PR DESCRIPTION
The command line options were not taken in account by phantomjs because they were at the end of the command line.

Before : 
`phantomjs path/to/render.js https://www.exemple.com 1024 768 10000 PNG false --ssl-protocol=tlsv1 --ignore-ssl-errors=true`

After : 
`phantomjs --ssl-protocol=tlsv1 --ignore-ssl-errors=true path/to/render.js https://www.exemple.com 1024 768 10000 PNG false`
